### PR TITLE
BAU repair deregistration test

### DIFF
--- a/PortalApi.Tests/PortalApiTests.cs
+++ b/PortalApi.Tests/PortalApiTests.cs
@@ -79,15 +79,11 @@ namespace PortalApi.Tests
 
             Assert.IsTrue(regResult.IsSuccess);
 
-            Thread.Sleep(3);
-
             var deregResult = await api.SubmitPortalDeregistrationAsync(
-                userToken.UserToken,
+                pushToken.ToString(),
                 deviceId);
 
             Assert.IsTrue(deregResult.IsSuccess);
         }
-
-
     }
 }

--- a/PortalApi.Tests/PortalApiTests.cs
+++ b/PortalApi.Tests/PortalApiTests.cs
@@ -79,6 +79,8 @@ namespace PortalApi.Tests
 
             Assert.IsTrue(regResult.IsSuccess);
 
+            // NB. providing the push token here does not seem fully correct.
+            // TODO: raise this with portal team - it would make sense to require the user token.
             var deregResult = await api.SubmitPortalDeregistrationAsync(
                 pushToken.ToString(),
                 deviceId);


### PR DESCRIPTION
Test method `DeregistrationEndpoint_Success` was failing with a 401 (unauthorised) response.

The call to the deregistration endpoint in the test was providing:
* user token
* device id

In fact the following are required:
* push token
* device id

With the change, it succeed with a 200 response.